### PR TITLE
fix: Improve binary path validation and set Unix file permissions

### DIFF
--- a/src/Devantler.HelmCLI/Helm.cs
+++ b/src/Devantler.HelmCLI/Helm.cs
@@ -30,9 +30,15 @@ public static class Helm
       _ => throw new PlatformNotSupportedException($"Unsupported platform: {Environment.OSVersion.Platform} {RuntimeInformation.ProcessArchitecture}"),
     };
     string binaryPath = Path.Combine(AppContext.BaseDirectory, binary);
-    return !File.Exists(binaryPath) ?
-      throw new FileNotFoundException($"{binaryPath} not found.") :
-      Cli.Wrap(binaryPath);
+    if (!File.Exists(binaryPath))
+    {
+      throw new FileNotFoundException($"{binaryPath} not found.");
+    }
+    if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+    {
+      File.SetUnixFileMode(binaryPath, UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute);
+    }
+    return Cli.Wrap(binaryPath);
   }
 
   /// <summary>


### PR DESCRIPTION
Enhance the validation of the binary path and apply appropriate Unix file permissions for non-Windows platforms.